### PR TITLE
Feat/método reutilizable que realice petición put a la api privada

### DIFF
--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -28,6 +28,10 @@ export const privatePut = async (url, id, params) => {
   return data;
 };
 
+export const privatePut = async (url, id, params) => {
+  const { data } = await axiosInstance.put(`${url}${id}`, params);
+  return data;
+};
 const Get = () => {
   axios
     .get('https://jsonplaceholder.typicode.com/users', config)

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -22,12 +22,6 @@ export const privateGet = async (url, id, params = {}) => {
   const { data } = axiosInstance.get(`${url}${idPlaceholder}`, { params });
   return data;
 };
-
-export const privatePut = async (url, id, params) => {
-  const { data } = await axiosInstance.put(`${url}${id}`, params);
-  return data;
-};
-
 export const privatePut = async (url, id, params) => {
   const { data } = await axiosInstance.put(`${url}${id}`, params);
   return data;

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -2,55 +2,61 @@ import axios from 'axios';
 const URL = 'http://ongapi.alkemy.org/private/api';
 
 const config = {
-    headers: {
-        Group: 91                //Aqui va el ID del equipo!!
-    }
-}
+  headers: {
+    Group: 91, //Aqui va el ID del equipo!!
+  },
+};
 
 const axiosInstance = axios.create({
-    baseURL: 'http://ongapi.alkemy.org/private/api',
+  baseURL: 'http://ongapi.alkemy.org/private/api',
 });
 
-axiosInstance.interceptors.request.use((config)=> {
-    config.headers.Authorization = getAuthorizationHeader();
-    config.headers.Group = 91;
-    return config
-})
+axiosInstance.interceptors.request.use((config) => {
+  config.headers.Authorization = getAuthorizationHeader();
+  config.headers.Group = 91;
+  return config;
+});
 
-export const privateGet = async (url,id,params={}) => {
-    const idPlaceholder = id ? `/${id}` : '';
-    const { data } = axiosInstance.get(`${url}${idPlaceholder}`, {params})
-    return data
+export const privateGet = async (url, id, params = {}) => {
+  const idPlaceholder = id ? `/${id}` : '';
+  const { data } = axiosInstance.get(`${url}${idPlaceholder}`, { params });
+  return data;
+};
+
+export const privatePut = async (url, id, params) => {
+  const { data } = await axiosInstance.put(`${url}${id}`, params);
+  return data;
 };
 
 const Get = () => {
-    axios.get('https://jsonplaceholder.typicode.com/users', config)
-    .then(res => console.log(res))
-    .catch(err => console.log(err))
+  axios
+    .get('https://jsonplaceholder.typicode.com/users', config)
+    .then((res) => console.log(res))
+    .catch((err) => console.log(err));
 };
 
 export const getAuthorizationHeader = () => {
-    const token = localStorage.getItem('token');
-    if(!token) return;
-    return {Authorization: `Bearer: ${token}`};
+  const token = localStorage.getItem('token');
+  if (!token) return;
+  return { Authorization: `Bearer: ${token}` };
 };
 
-const verifyProps = (path,id,body) => {
-    if (!path || !id || !body) {
-        throw new Error(`props not specified for async action put`);
-    };
+const verifyProps = (path, id, body) => {
+  if (!path || !id || !body) {
+    throw new Error(`props not specified for async action put`);
+  }
 };
 
-export const privateRequestPut = async(path,id,body) => {
-    verifyProps(path,id,body)
+export const privateRequestPut = async (path, id, body) => {
+  verifyProps(path, id, body);
 
-    const {Authorization}=getAuthorizationHeader();
+  const { Authorization } = getAuthorizationHeader();
 
-    const headers={...config.headers,Authorization}
+  const headers = { ...config.headers, Authorization };
 
-    let {data} = await axios.put(`${URL}/${path}/${id}`,body,headers);
+  let { data } = await axios.put(`${URL}/${path}/${id}`, body, headers);
 
-    return data;
+  return data;
 };
 
 export default Get;

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -28,10 +28,6 @@ export const privatePut = async (url, id, params) => {
   return data;
 };
 
-export const privatePut = async (url, id, params) => {
-  const { data } = await axiosInstance.put(`${url}${id}`, params);
-  return data;
-};
 const Get = () => {
   axios
     .get('https://jsonplaceholder.typicode.com/users', config)


### PR DESCRIPTION
Method that receives a destination route, an identifier and an object with the data structure to send in the BODY and invokes the motodo to add the Authorization header based on the user's token and make a PUT request

LInk to useStory:
https://alkemy-labs.atlassian.net/jira/software/c/projects/OT91/boards/145?modal=detail&selectedIssue=OT91-71


