### PR TITLE
Feat/config project/method reusable for request put

### DIFF
--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -1,4 +1,10 @@
 import axios from 'axios';
+const URL = 'http://ongapi.alkemy.org/api'
+const token = localStorage.getItem('token');
+
+const headers = {
+    'Authorization': token,
+};
 
 const config = {
     headers: {
@@ -10,6 +16,16 @@ const Get = () => {
     axios.get('https://jsonplaceholder.typicode.com/users', config)
     .then(res => console.log(res))
     .catch(err => console.log(err))
+}
+
+
+
+export const privateRequestPut = async(path,id,body) => {
+    if (!path || !id || !body) {
+        throw new Error(`props not specified for async action put`);
+    }
+ let {data} = await axios.put(`${URL}/${path}/${id},`,headers,body)
+ return data
 }
 
 export default Get

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-const URL = 'http://ongapi.alkemy.org/api';
+const URL = 'http://ongapi.alkemy.org/private/api';
 
 const config = {
     headers: {

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+const URL = 'http://ongapi.alkemy.org/private/api';
 
 const config = {
     headers: {
@@ -10,12 +11,30 @@ const Get = () => {
     axios.get('https://jsonplaceholder.typicode.com/users', config)
     .then(res => console.log(res))
     .catch(err => console.log(err))
-}
-
-export default Get;
+};
 
 export const getAuthorizationHeader = () => {
     const token = localStorage.getItem('token');
     if(!token) return;
     return {Authorization: `Bearer: ${token}`};
+};
+
+const verifyProps = (path,id,body) => {
+    if (!path || !id || !body) {
+        throw new Error(`props not specified for async action put`);
+    };
 }
+
+export const privateRequestPut = async(path,id,body) => {
+    verifyProps(path,id,body)
+
+    const {Authorization}=getAuthorizationHeader();
+
+    const headers={...config.headers,Authorization}
+
+    let {data} = await axios.put(`${URL}/${path}/${id}`,body,headers);
+
+    return data;
+};
+
+export default Get;


### PR DESCRIPTION
-add reusable method for put requests to private routes;
-add functions to render error if any of the data is missing;

![1](https://user-images.githubusercontent.com/75461111/140679835-79647a8d-fc2f-4a45-a614-dfce0e7ad0be.png)
