### PR TITLE
Crear componente para renderizar sección "Nosotros" V2

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ import OrganizationEditionForm from './Components/Organization/OrganizationEditi
 import NewsDetailLayout from './Components/News/Detail/NewsDetailLayout';
 import ActivitiesList from './Components/Activities/ActivitiesList';
 import Home from './Components/Home';
+import AboutUs from "./Components/About/AboutUs";
 function App() {
   return (
     <>
@@ -46,6 +47,7 @@ function App() {
           <Route path="/novedades/:id" component={NewsDetailLayout} />
           <Route path="/activity-detail/:id" component={Detail} />
           <Route path="/activities" component={ActivitiesList} />
+          <Route path="/nosotros" component={AboutUs} />
         </Switch>
       </BrowserRouter>
     </>

--- a/src/Components/About/AboutUs.js
+++ b/src/Components/About/AboutUs.js
@@ -1,0 +1,20 @@
+import Title from "../Title/Title";
+import { Box } from "@material-ui/core";
+import '../../Styles/Container.css';
+
+const AboutUs = () => {
+    const description = `Somos un centro comunitario que acompaña a más de 700 personas a través de las áreas de:
+        Educación, deportes, primera infancia, salud, alimentación y trabajo social.`
+    return (
+        <>
+            <Box className="title-container">
+                <Title title="Nosotros"/>
+                <div className="title-container-text">
+                    <p>{description}</p>
+                </div>
+            </Box>
+        </>
+    )
+}
+
+export default AboutUs;

--- a/src/Styles/Container.css
+++ b/src/Styles/Container.css
@@ -1,0 +1,19 @@
+.title-container {
+    position: relative;
+    width: 100%;
+}
+
+.title-container-text {
+    width: 100%;
+    position: absolute;
+    top: 55%;
+    text-align: center;
+}
+
+.title-container-text p {
+    display: inline-block;
+    width: 90%;
+    max-width: 700px;
+    font-size: 18px;
+    line-height: 30px;
+}


### PR DESCRIPTION
User story link: https://alkemy-labs.atlassian.net/browse/OT91-54
This is a correction of the previous PR: https://github.com/alkemyTech/OT91-server/pull/21, which contains out of scope changes (That I could not solve).

**##SUMMARY**
It show the Title component in the top section of AboutUs, in /nosotros route. And apply feedback of the previous PR.

**##CHANGES ADDED**
- Render AboutUs in /nosotros route
- Remove AboutUsDescription component: And move It to AboutUs component
- AboutUs component displays the Title component and a description text below the title.
- Change AboutUs styles to Container styles
- Use description const in AboutUs.js: Represents a description obtained with an API request

**##SCREENSHOTS**
![image](https://user-images.githubusercontent.com/50643955/140741792-0b8e3343-9a9f-43f7-909e-94aaeaa6c455.png)
