### PR TITLE
Feat/Novedades/Agregar loading en novedades

### DIFF
--- a/src/Components/News/Detail/NewsDetailLayout.js
+++ b/src/Components/News/Detail/NewsDetailLayout.js
@@ -36,6 +36,7 @@ const NewsDetailLayout = () => {
     setIsLoading(false);
   }, [id, stripedHtml]);
 
+
   return (
     <div>
       {loading ? (

--- a/src/Components/News/Detail/NewsDetailLayout.js
+++ b/src/Components/News/Detail/NewsDetailLayout.js
@@ -1,9 +1,10 @@
 import React, { useEffect, useState, useCallback, lazy, Suspense } from "react";
 import { useParams } from "react-router";
 import NewsTitle from "./NewsTittle";
-import { Box } from "@material-ui/core";
+import { Box } from "@mui/material";
 import { getNewById } from "../../../Services/newsServices";
 import LoadingSpinner from "../../../Utils/loadingSpinner";
+import "../../../Styles/CardStyle.css";
 
 const NewsImage = lazy(
   () =>
@@ -15,6 +16,7 @@ const NewsImage = lazy(
 const NewsDetailLayout = () => {
   const [newData, setNewData] = useState({});
   const [newsDescription, setNewsDescription] = useState("");
+  const [loading, setIsLoading] = useState(true);
 
   const { id } = useParams();
 
@@ -31,15 +33,24 @@ const NewsDetailLayout = () => {
   useEffect(() => {
     loadNewData();
     stripedHtml();
+    setIsLoading(false);
   }, [id, stripedHtml]);
 
   return (
     <div>
-      <NewsTitle title={newData.name} />
-      <Suspense fallback={<LoadingSpinner />}>
-        <NewsImage image={newData.image} />
-      </Suspense>
-      <Box>{newsDescription}</Box>
+      {loading ? (
+        <div className="spinner">
+          <LoadingSpinner />
+        </div>
+      ) : (
+        <div>
+          <NewsTitle title={newData.name} />
+          <Suspense fallback={<LoadingSpinner />}>
+            <NewsImage image={newData.image} />
+          </Suspense>
+          <Box>{newsDescription}</Box>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/Components/News/NewsList.js
+++ b/src/Components/News/NewsList.js
@@ -1,55 +1,46 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import "../../Styles/CardStyle.css";
 import { listHasValues } from "../../Utils/validation";
 import Title from "../Title/Title";
 import CustomCard from "../Card/CustomCard";
 import { Container } from "@mui/material";
-const lastNewsMock = [
-  {
-    id: 626,
-    name: "VI Jornada recreativa",
-    content:
-      "Se realizó la VI jornada recreativa de invierno, jovenes de todas las edades participarion en juegos y los más chicos presentaron una coreografía espectacular!",
-    image: "https://ukrainer.net/wp-content/uploads/2019/11/11-99.jpg",
-  },
-  {
-    id: 629,
-    name: "Jornada domigo juguetes 12",
-    content:
-      "VI jornada recreativa de invierno, jovenes de todas las edades participarion en juegos y los m&aacute;s chicos presentaron una core",
-    image: "https://ukrainer.net/wp-content/uploads/2019/11/0-113.jpg",
-    user_id: null,
-  },
-  {
-    id: 637,
-    name: "Actividades anuales",
-    content:
-      "Jornada recreativa de invierno, jovenes de todas las edades participarion en juegos y los m&aacute;s chicos presentaron una core",
-    image:
-      "https://www.kleineherzen.or.at/wp-content/uploads/Kids_Mutter_Kind_haus2019.png",
-  },
-];
+import LoadingSpinner from "../../Utils/loadingSpinner";
+
 const NewsList = ({ lastNews }) => {
-  const newsListHasValues = listHasValues(lastNewsMock);
+  const [loading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    lastNews && setIsLoading(false);
+  }, [lastNews]);
+
+  const newsListHasValues = listHasValues(lastNews);
   return (
     <Container className="ContainerList">
-      <Title title="Novedades" />
-      <ul className="list-container">
-        {newsListHasValues ? (
-          lastNewsMock.map((news) => {
-            return (
-              <CustomCard
-                key={news.id}
-                title={news.name}
-                img={news.image}
-                description={news.content}
-              />
-            );
-          })
-        ) : (
-          <p>No hay novedades</p>
-        )}
-      </ul>
+      {loading ? (
+        <div className="spinner">
+          <LoadingSpinner />
+        </div>
+      ) : (
+        <div>
+          <Title title="Novedades" />
+          <ul className="list-container">
+            {newsListHasValues ? (
+              lastNews.map((news) => {
+                return (
+                  <CustomCard
+                    key={news.id}
+                    title={news.name}
+                    img={news.image}
+                    description={news.content}
+                  />
+                );
+              })
+            ) : (
+              <p>No hay novedades</p>
+            )}
+          </ul>
+        </div>
+      )}
     </Container>
   );
 };

--- a/src/Components/News/NewsList.js
+++ b/src/Components/News/NewsList.js
@@ -7,7 +7,7 @@ import { Container } from "@mui/material";
 import LoadingSpinner from "../../Utils/loadingSpinner";
 
 const NewsList = ({ lastNews }) => {
-  const [loading, setIsLoading] = useState(false);
+  const [loading, setIsLoading] = useState(true);
 
   useEffect(() => {
     lastNews && setIsLoading(false);
@@ -23,7 +23,7 @@ const NewsList = ({ lastNews }) => {
       ) : (
         <div>
           <Title title="Novedades" />
-          <ul className="list-container">
+          <ul className="list-grid-container ">
             {newsListHasValues ? (
               lastNews.map((news) => {
                 return (

--- a/src/Styles/CardStyle.css
+++ b/src/Styles/CardStyle.css
@@ -5,10 +5,10 @@
   justify-content: center;
 }
 
-.list-container {
-  display: flex;
-  justify-content: space-around;
-  gap: 20px;
+.list-grid-container {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-gap: 10px;
   margin-top: 50px;
 }
 

--- a/src/Styles/CardStyle.css
+++ b/src/Styles/CardStyle.css
@@ -4,6 +4,7 @@
 .ContainerList {
   justify-content: center;
 }
+
 .list-container {
   display: flex;
   justify-content: space-around;
@@ -16,4 +17,11 @@
   padding: 10px 30px;
   background-color: #a1d4f6;
   border-radius: 5px;
+}
+.spinner {
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }


### PR DESCRIPTION

**##SUMMARY** 
This PR adds the loader component to the News List and New Detail components.

**##CHANGES ADDED**
-Logic to wait for the api data
-Fixes in styles to center the loading component and visualize the cards well in the News List component
-Fixes in the New Detail component because the api data was not being rendered well

**##EVIDENCE**
The tests have been recorded passing the data to the components through the getNews function and simulating slow internet to be able to see the loading component well.
New Detail Component: https://www.loom.com/share/879535681efb4e60a13bc3fdabd401c8
NewList Component: https://www.loom.com/share/33c45c1f25c64c71b6e5a04f315306ca

**##USERSTORY**
https://alkemy-labs.atlassian.net/jira/software/c/projects/OT91/boards/145?modal=detail&selectedIssue=OT91-97&assignee=70121%3Aad4a2c05-0941-42e8-af44-540b8eff3169