### PR TITLE
Feat/Actividades/Mostrar errores cuando las peticiones no se realicen correctamente

### DIFF
--- a/src/Components/Activities/ActivitiesCards/ActivitiesCards.js
+++ b/src/Components/Activities/ActivitiesCards/ActivitiesCards.js
@@ -1,11 +1,11 @@
 import {NO_ACTIVITIES} from '../../common/text/textActivity';
 import{setCKEditorText} from '../../common/ckEditor/setCKEditorText';
-import { isValidList } from '../../../Services/activityService';
+import activityService from '../../../Services/activityService';
 const ActivitiesCards = ({activities}) => {
 
     return (
         <div>
-            {isValidList(activities) ? activities.map(e=> <div>
+            {activityService.isValidList(activities) ? activities.map(e=> <div>
                 <img src={e.image} alt={e.name}/>
                 <h3>{e.name}</h3>
                 <p>{setCKEditorText(e,'description').description}</p>

--- a/src/Components/Activities/ActivitiesCards/ActivitiesCards.js
+++ b/src/Components/Activities/ActivitiesCards/ActivitiesCards.js
@@ -1,6 +1,6 @@
 import {NO_ACTIVITIES} from '../../common/text/textActivity';
 import{setCKEditorText} from '../../common/ckEditor/setCKEditorText';
-import activityService from '../../../Services/activityService';
+import * as activityService from '../../../Services/activityService';
 const ActivitiesCards = ({activities}) => {
 
     return (

--- a/src/Components/Activities/ActivitiesForm.js
+++ b/src/Components/Activities/ActivitiesForm.js
@@ -7,7 +7,7 @@ import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 import { CustomErrorMessage } from '../common/CustomErrorMessage';
 import {setCKEditorText} from '../common/ckEditor/setCKEditorText';
 import { validateForm} from '../common/validations/validateForm';
-import activityService from '../../Services/activityService';
+import * as activityService from '../../Services/activityService';
 const ActivitiesForm = () => {
   const {activityId} = useParams();
   const [activity, setActivity] = useState({
@@ -26,7 +26,7 @@ const ActivitiesForm = () => {
 
   const handleSubmit = (values,resetForm) => {
     let updatedValues =setCKEditorText(values,'description')
-    activityService.createOrUpdateActivity(activityId,updatedValues)
+    activityService.createOrUpdate(activityId,updatedValues)
     resetForm();
   }
 

--- a/src/Components/Activities/ActivitiesForm.js
+++ b/src/Components/Activities/ActivitiesForm.js
@@ -7,7 +7,7 @@ import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 import { CustomErrorMessage } from '../common/CustomErrorMessage';
 import {setCKEditorText} from '../common/ckEditor/setCKEditorText';
 import { validateForm} from '../common/validations/validateForm';
-import {createOrUpdateActivity} from '../../Services/activityService';
+import activityService from '../../Services/activityService';
 const ActivitiesForm = () => {
   const {activityId} = useParams();
   const [activity, setActivity] = useState({
@@ -26,7 +26,7 @@ const ActivitiesForm = () => {
 
   const handleSubmit = (values,resetForm) => {
     let updatedValues =setCKEditorText(values,'description')
-    createOrUpdateActivity(activityId,updatedValues)
+    activityService.createOrUpdateActivity(activityId,updatedValues)
     resetForm();
   }
 

--- a/src/Components/Activities/ActivitiesList.js
+++ b/src/Components/Activities/ActivitiesList.js
@@ -2,7 +2,7 @@ import '../CardListStyles.css';
 import Title from '../Title/Title';
 import { useEffect, useState } from 'react';
 import {ACTIVITIES} from '../common/text/textActivity';
-import {getAllActivities} from '../../Services/activityService';
+import activityService from '../../Services/activityService';
 import ActivitiesCards from './ActivitiesCards/ActivitiesCards';
 import ListPagination from '../common/ListPagination/ListPagination';
 const ActivitiesList = () => {
@@ -10,7 +10,7 @@ const ActivitiesList = () => {
     const [items, setItems] = useState([]);
 
     useEffect(async() => {
-        getAllActivities()
+        activityService.getAllActivities()
             .then(allActivities => setItems(allActivities));
     }, []);
 

--- a/src/Components/Activities/ActivitiesList.js
+++ b/src/Components/Activities/ActivitiesList.js
@@ -2,7 +2,7 @@ import '../CardListStyles.css';
 import Title from '../Title/Title';
 import { useEffect, useState } from 'react';
 import {ACTIVITIES} from '../common/text/textActivity';
-import activityService from '../../Services/activityService';
+import  * as activityService from '../../Services/activityService';
 import ActivitiesCards from './ActivitiesCards/ActivitiesCards';
 import ListPagination from '../common/ListPagination/ListPagination';
 const ActivitiesList = () => {
@@ -10,7 +10,7 @@ const ActivitiesList = () => {
     const [items, setItems] = useState([]);
 
     useEffect(async() => {
-        activityService.getAllActivities()
+        activityService.getAll()
             .then(allActivities => setItems(allActivities));
     }, []);
 

--- a/src/Components/Activities/Detail/Detail.js
+++ b/src/Components/Activities/Detail/Detail.js
@@ -3,7 +3,7 @@ import axios from "axios";
 import { useParams } from "react-router-dom";
 import {Card,CardContent,CardMedia,Typography,CardActionArea} from "@mui/material";
 import Title from "../../Title/Title";
-import getActivityById from '../../../Services/activityService'
+import  * as activityService from '../../../Services/activityService'
 import "../../../Styles/CardStyle.css";
 
 const Detail = () => {
@@ -17,7 +17,7 @@ const Detail = () => {
   }, [activity.description]);
 
   useEffect(() => {
-    getActivityById(id)
+    activityService.getById(id)
       .then((activityData) => {
           setActivity(activityData);
           stripedHtml();

--- a/src/Services/activityService.js
+++ b/src/Services/activityService.js
@@ -1,45 +1,63 @@
-import axios from 'axios';
+import axios from "axios";
+import { alertCrudMessages as alert } from "../Utils/alertCrudMessages";
 
-const URL = process.env.REACT_APP_ACTIVITY_URL;
-
-export const getActivityById = async (id) => {
-    let {data}= await axios.get(`${URL}/${id}`);
-    return data;
-}
-export const modifyActivity = async (id,body) => {
-    let {data}= await axios.put(`${URL}/${id}`,body);
-    return data;
-};
-
-export const createActivity = async (body) => {
-    let {data}= await axios.post(`${URL}`,body);
-    return data;
-};
-
-export const deleteActivityById = async (activityId) => {
-    return await axios.delete(`${URL}/activities/${activityId}`)
-        .then(response => response.data);
-}
-
-export const createOrUpdateActivity = async (activityId,body)=>{
-    const activityCreatedOrUpdated = await getActivity(activityId)
-        .then(activity => modifyActivity(activityId, body))
-        .catch(_ => createActivity(body));
-    return activityCreatedOrUpdated;
-};
+const URL = "http://ongapi.alkemy.org/api/activities";
+// const URL = process.env.REACT_APP_ACTIVITY_URL;
 
 const getActivity = async (id) => {
-    const activity = await axios.get(`${URL}/activities/${id}`)
-        .then(response => response.data.data)
-    return activity;
+  return await axios
+    .get(`${URL}/${id}`)
+    .then((response) => response.data.data)
+    .catch(() => alert.READ_ERROR("la actividad"));
 };
 
-export const getAllActivities = async () =>{
-    const allActivities = await axios.get(`${URL}/activities`)
-        .then(response => response.data.data);
-    return allActivities;
+const getAllActivities = async () => {
+  return await axios
+    .get(`${URL}`)
+    .then((response) => response.data.data)
+    .catch(() => alert.READ_ERROR("las actividades"));
+};
+const createActivity = async (body) => {
+  return await axios
+    .post(`${URL}`, body)
+    .then((response) => response.data)
+    .catch(() => alert.CREATE_ERROR("la actividad"));
 };
 
-export const isValidList = list => list && list.length > 0;
+const modifyActivity = async (id, body) => {
+  return await axios
+    .put(`${URL}/${id}`, body)
+    .then((response) => response.data)
+    .catch(() => alert.UPDATE_ERROR("la actividad"));
+};
 
-export default getActivity;
+const deleteActivityById = async (activityId) => {
+  return await axios
+    .delete(`${URL}/${activityId}`)
+    .then((response) => response.data)
+    .catch(() => alert.DELETE_ERROR("la actividad"));
+};
+
+const createOrUpdateActivity = async (body, activityId) => {
+  if (activityId) {
+    await getActivity(activityId);
+    const data = await modifyActivity(body, ac);
+    return data;
+  } else if (!activityId && body) {
+    const data = await createActivity(body);
+    return data;
+  }
+};
+const isValidList = (list) => list && list.length > 0;
+
+const activityService = {
+  getActivity,
+  getAllActivities,
+  createActivity,
+  modifyActivity,
+  deleteActivityById,
+  createOrUpdateActivity,
+  isValidList,
+};
+
+export default activityService;

--- a/src/Services/activityService.js
+++ b/src/Services/activityService.js
@@ -3,41 +3,41 @@ import { alertCrudMessages as alert } from "../Utils/alertCrudMessages";
 
 const URL = process.env.REACT_APP_ACTIVITY_URL;
 
-const getActivity = async (id) => {
+export const getById = async (id) => {
   return await axios
     .get(`${URL}/${id}`)
     .then((response) => response.data.data)
     .catch(() => alert.READ_ERROR("la actividad"));
 };
 
-const getAllActivities = async () => {
+export const getAll = async () => {
   return await axios
     .get(`${URL}`)
     .then((response) => response.data.data)
     .catch(() => alert.READ_ERROR("las actividades"));
 };
-const createActivity = async (body) => {
+export const create = async (body) => {
   return await axios
     .post(`${URL}`, body)
     .then((response) => response.data)
     .catch(() => alert.CREATE_ERROR("la actividad"));
 };
 
-const modifyActivity = async (id, body) => {
+export const update = async (id, body) => {
   return await axios
     .put(`${URL}/${id}`, body)
     .then((response) => response.data)
     .catch(() => alert.UPDATE_ERROR("la actividad"));
 };
 
-const deleteActivityById = async (activityId) => {
+export const deleteById = async (activityId) => {
   return await axios
     .delete(`${URL}/${activityId}`)
     .then((response) => response.data)
     .catch(() => alert.DELETE_ERROR("la actividad"));
 };
 
-const createOrUpdateActivity = async (body, activityId) => {
+export const createOrUpdate = async (body, activityId) => {
   if (activityId) {
     await getActivity(activityId);
     const data = await modifyActivity(body, ac);
@@ -47,16 +47,5 @@ const createOrUpdateActivity = async (body, activityId) => {
     return data;
   }
 };
-const isValidList = (list) => list && list.length > 0;
 
-const activityService = {
-  getActivity,
-  getAllActivities,
-  createActivity,
-  modifyActivity,
-  deleteActivityById,
-  createOrUpdateActivity,
-  isValidList,
-};
-
-export default activityService;
+export const isValidList = (list) => list && list.length > 0;

--- a/src/Services/activityService.js
+++ b/src/Services/activityService.js
@@ -1,8 +1,7 @@
 import axios from "axios";
 import { alertCrudMessages as alert } from "../Utils/alertCrudMessages";
 
-const URL = "http://ongapi.alkemy.org/api/activities";
-// const URL = process.env.REACT_APP_ACTIVITY_URL;
+const URL = process.env.REACT_APP_ACTIVITY_URL;
 
 const getActivity = async (id) => {
   return await axios

--- a/src/Utils/alertCrudMessages.js
+++ b/src/Utils/alertCrudMessages.js
@@ -1,0 +1,21 @@
+import { showErrorAlert } from "./alerts";
+
+const CREATE_ERROR = (element) => {
+  return showErrorAlert(`No hemos podido crear ${element}`);
+};
+const READ_ERROR = (element) => {
+  return showErrorAlert(`No hemos podido leer ${element}`);
+};
+const UPDATE_ERROR = (element) => {
+  return showErrorAlert(`No hemos podido actualizar ${element}`);
+};
+const DELETE_ERROR = (element) => {
+  return showErrorAlert(`No hemos podido eliminar ${element}`);
+};
+
+export const alertCrudMessages = {
+  CREATE_ERROR,
+  READ_ERROR,
+  UPDATE_ERROR,
+  DELETE_ERROR,
+};


### PR DESCRIPTION
**##SUMMARY**
Using the reusable alert components, this component displays an error to the user when requests made from the activity service have an error

**##CHANGES ADDED**
-Add the reusable component errorCrudMessage to handle the errors in the crud methods passing only the end of the error message depending on the component that is executing it.
-Logic to handle errors in raw service methods
-Fixes in environment variables because some paths were not working
-Fix in createOrUpdate function because it didn't work correctly
-Customization of the service component for a more unified and clean code.
-Change of routes in activity files due to export mode change in activity service 

**##EVIDENCE**
Screenshot tests contain a successful call (which can be viewed in the network history) and a last rejected call

![GetById](https://user-images.githubusercontent.com/83502436/142013684-b8dfe3b6-5332-43dd-8bbe-11b6fba969a3.jpg)
![Create](https://user-images.githubusercontent.com/83502436/142013692-0d09a66c-1df6-4bc9-9c76-09d8b293cde5.png)
![Delete (2)](https://user-images.githubusercontent.com/83502436/142013700-1cce49f9-7693-4f3b-a173-ea44106d90b2.png)
![Modify](https://user-images.githubusercontent.com/83502436/142013705-3025cdb9-9721-4af7-9b02-922d2f817f2d.png)
.


**##USERSTORY**
https://alkemy-labs.atlassian.net/jira/software/c/projects/OT91/boards/145?modal=detail&selectedIssue=OT91-104&assignee=70121%3Aad4a2c05-0941-42e8-af44-540b8eff3169
