### PR TITLE
Mostrar errores cuando las peticiones no se realicen correctamente (Novedades)

### DIFF
--- a/src/Services/newsServices.js
+++ b/src/Services/newsServices.js
@@ -2,7 +2,7 @@ import axios from "axios";
 import { showErrorAlert } from "../Utils/alerts";
 
 const URL = process.env.REACT_APP_API_URL_NEWS;
-const handleCatch = (error) => showErrorAlert(error.message);
+const handleCatch = (error) => showErrorAlert(error.response.data.message || error.message);
 
 const getNews = async () => {
   try{

--- a/src/Services/newsServices.js
+++ b/src/Services/newsServices.js
@@ -10,17 +10,16 @@ const getNews = async () => {
       const data = response.data.data;
       return data;
   }catch(error){
-    console.log(error)
+    handleCatch(error);
   }
 };
 
 const getNewById = async (id) => {
   try{
     const {data}= await axios.get(`${URL}/${id}`)
-      .catch(handleCatch);
     return data
   }catch(error) {
-    console.log(error)
+    handleCatch(error);
   }
 }
 

--- a/src/Services/newsServices.js
+++ b/src/Services/newsServices.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { showErrorAlert } from "../Utils/alerts";
 
 const URL = process.env.REACT_APP_API_URL_NEWS;
 
@@ -15,6 +16,7 @@ const getNews = async () => {
 const getNewById = async (id) => {
   try{
     const {data}= await axios.get(`${URL}/${id}`)
+      .catch(_ => showErrorAlert("No se ha podido obtener la novedad"))
     return data
   }catch(error) {
     console.log(error)
@@ -26,7 +28,7 @@ const updateNewById = async (id,dataToUpdate) => {
     const data = await axios.put(`${URL}/${id}`,dataToUpdate)
     return data
   }catch (error) {
-    console.log(error)
+    showErrorAlert("No se ha podido actualizar la novedad");
   }
 }
 
@@ -35,7 +37,7 @@ const createNew = async (news) => {
     const data = await axios.put(URL, news)
     return data
   }catch ( error ) {
-    console.log(error)
+    showErrorAlert("No se ha podido crear la novedad");
   }
 }
 
@@ -58,7 +60,7 @@ const deleteNewByid = async (id) => {
     const data = await axios.delete(`${URL}/${id}`)
     return data
   }catch(error){
-    console.log(error)
+    showErrorAlert("No se ha podido eliminar la novedad");
   }
 }
 

--- a/src/Services/newsServices.js
+++ b/src/Services/newsServices.js
@@ -2,6 +2,7 @@ import axios from "axios";
 import { showErrorAlert } from "../Utils/alerts";
 
 const URL = process.env.REACT_APP_API_URL_NEWS;
+const handleCatch = (error) => showErrorAlert(error.message);
 
 const getNews = async () => {
   try{
@@ -16,7 +17,7 @@ const getNews = async () => {
 const getNewById = async (id) => {
   try{
     const {data}= await axios.get(`${URL}/${id}`)
-      .catch(_ => showErrorAlert("No se ha podido obtener la novedad"))
+      .catch(handleCatch);
     return data
   }catch(error) {
     console.log(error)
@@ -28,7 +29,7 @@ const updateNewById = async (id,dataToUpdate) => {
     const data = await axios.put(`${URL}/${id}`,dataToUpdate)
     return data
   }catch (error) {
-    showErrorAlert("No se ha podido actualizar la novedad");
+    handleCatch(error);
   }
 }
 
@@ -37,7 +38,7 @@ const createNew = async (news) => {
     const data = await axios.put(URL, news)
     return data
   }catch ( error ) {
-    showErrorAlert("No se ha podido crear la novedad");
+    handleCatch(error)
   }
 }
 
@@ -60,7 +61,7 @@ const deleteNewByid = async (id) => {
     const data = await axios.delete(`${URL}/${id}`)
     return data
   }catch(error){
-    showErrorAlert("No se ha podido eliminar la novedad");
+    handleCatch(error);
   }
 }
 


### PR DESCRIPTION
User story link: https://alkemy-labs.atlassian.net/browse/OT91-102

**##SUMMARY**
Reuse alerts to give feedback to the user when requests for news have errors

**##CHANGES ADDED**
- Idem *SUMMARY*: Using them in the .catch