### PR TITLE
Fix wrong imports for mui components

### DIFF
--- a/src/Components/News/Detail/NewsDetailLayout.js
+++ b/src/Components/News/Detail/NewsDetailLayout.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useCallback, lazy, Suspense } from "react";
 import { useParams } from "react-router";
 import NewsTitle from "./NewsTittle";
-import { Box } from "@material-ui/core";
+import { Box } from "@mui/material";
 import { getNewById } from "../../../Services/newsServices";
 import LoadingSpinner from "../../../Utils/loadingSpinner";
 

--- a/src/Components/Slides/ListSlides/ListSlides.js
+++ b/src/Components/Slides/ListSlides/ListSlides.js
@@ -1,12 +1,12 @@
 import {useState, useEffect} from 'react';
-import Paper from '@material-ui/core/Paper';
-import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableContainer from '@material-ui/core/TableContainer';
-import TableHead from '@material-ui/core/TableHead';
-import TablePagination from '@material-ui/core/TablePagination';
-import TableRow from '@material-ui/core/TableRow';
+import Paper from '@mui/material/Paper';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TablePagination from '@mui/material/TablePagination';
+import TableRow from '@mui/material/TableRow';
 
 const columns = [
   'title','image','order'


### PR DESCRIPTION
### Summary
Due to Material UI's update from Version 4 to Version 5, some imports were out of date.

### Changes added
Replace `@material-ui/core` to `@mui/material` in the imports affected.