### PR TITLE
Crear reducer de actividades

### DIFF
--- a/src/Components/Activities/ActivitiesForm.js
+++ b/src/Components/Activities/ActivitiesForm.js
@@ -1,4 +1,4 @@
-import { useState} from 'react';
+import { useEffect, useState } from 'react';
 import {useParams} from 'react-router'
 import {Formik, Form, Field} from 'formik';
 import { setUrlImage } from '../common/File';
@@ -7,11 +7,12 @@ import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 import { CustomErrorMessage } from '../common/CustomErrorMessage';
 import {setCKEditorText} from '../common/ckEditor/setCKEditorText';
 import { validateForm} from '../common/validations/validateForm';
-import { createOrUpdate } from '../../app/activitiesReducer/activitiesReducer';
+import * as activitiesReducer from '../../app/activitiesReducer/activitiesReducer';
 import { useDispatch } from 'react-redux';
 const ActivitiesForm = () => {
   const {activityId} = useParams();
   const [activity, setActivity] = useState({
+    id: activityId,
     name:'',
     description:'',
     image: ''
@@ -20,6 +21,9 @@ const ActivitiesForm = () => {
   const handleChangeDescription = (description, setFieldValue) => {
     setFieldValue("description", description.getData())
   };
+  useEffect(() => {
+    dispatch(activitiesReducer.getAll())
+  })
 
   const handleChangeImage = (e, setImage) =>{
     setUrlImage(e.target.files[0],setImage)
@@ -27,7 +31,7 @@ const ActivitiesForm = () => {
 
   const handleSubmit = (values,resetForm) => {
     let updatedValues =setCKEditorText(values,'description')
-    dispatch(createOrUpdate(activityId,updatedValues));
+    dispatch(activitiesReducer.createOrUpdate(values));
     resetForm();
   }
 

--- a/src/Components/Activities/ActivitiesForm.js
+++ b/src/Components/Activities/ActivitiesForm.js
@@ -7,7 +7,8 @@ import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 import { CustomErrorMessage } from '../common/CustomErrorMessage';
 import {setCKEditorText} from '../common/ckEditor/setCKEditorText';
 import { validateForm} from '../common/validations/validateForm';
-import * as activityService from '../../Services/activityService';
+import { createOrUpdate } from '../../app/activitiesReducer/activitiesReducer';
+import { useDispatch } from 'react-redux';
 const ActivitiesForm = () => {
   const {activityId} = useParams();
   const [activity, setActivity] = useState({
@@ -15,7 +16,7 @@ const ActivitiesForm = () => {
     description:'',
     image: ''
   });
-
+  const dispatch = useDispatch();
   const handleChangeDescription = (description, setFieldValue) => {
     setFieldValue("description", description.getData())
   };
@@ -26,7 +27,7 @@ const ActivitiesForm = () => {
 
   const handleSubmit = (values,resetForm) => {
     let updatedValues =setCKEditorText(values,'description')
-    activityService.createOrUpdate(activityId,updatedValues)
+    dispatch(createOrUpdate(activityId,updatedValues));
     resetForm();
   }
 

--- a/src/Components/Activities/ActivitiesList.js
+++ b/src/Components/Activities/ActivitiesList.js
@@ -2,16 +2,15 @@ import '../CardListStyles.css';
 import Title from '../Title/Title';
 import { useEffect, useState } from 'react';
 import {ACTIVITIES} from '../common/text/textActivity';
-import  * as activityService from '../../Services/activityService';
 import ActivitiesCards from './ActivitiesCards/ActivitiesCards';
 import ListPagination from '../common/ListPagination/ListPagination';
+import { useDispatch, useSelector } from 'react-redux';
+import { getAll } from '../../app/activitiesReducer/activitiesReducer';
 const ActivitiesList = () => {
-
-    const [items, setItems] = useState([]);
-
-    useEffect(async() => {
-        activityService.getAll()
-            .then(allActivities => setItems(allActivities));
+    const {activities: items} = useSelector(state => state.activities);
+    const dispatch = useDispatch();
+    useEffect(() => {
+        dispatch(getAll());
     }, []);
 
     const showItemsListComponent = (items) => (<ActivitiesCards activities={items} />);

--- a/src/Components/Activities/Detail/Detail.js
+++ b/src/Components/Activities/Detail/Detail.js
@@ -3,25 +3,24 @@ import axios from "axios";
 import { useParams } from "react-router-dom";
 import {Card,CardContent,CardMedia,Typography,CardActionArea} from "@mui/material";
 import Title from "../../Title/Title";
-import  * as activityService from '../../../Services/activityService'
+import { getById } from "../../../app/activitiesReducer/activitiesReducer";
+import { useSelector } from "react-redux";
 import "../../../Styles/CardStyle.css";
+import { useDispatch } from "react-redux";
 
 const Detail = () => {
   const { id } = useParams();
-  const [activity, setActivity] = useState("");
+  const activity = useSelector(state => state.activities.activity);
   const [activityDescription, setActivityDescription] = useState("");
 
   const stripedHtml = useCallback(() => {
     activity.description &&
       setActivityDescription(activity.description.replace(/<[^>]+>/g, ""));
   }, [activity.description]);
-
+  const dispatch = useDispatch();
   useEffect(() => {
-    activityService.getById(id)
-      .then((activityData) => {
-          setActivity(activityData);
-          stripedHtml();
-        })
+    dispatch(getById(id));
+    stripedHtml();
   }, [stripedHtml]);
 
   return (

--- a/src/Components/Backoffice/ActivitiesBackOffice/ActivitiesTable.js
+++ b/src/Components/Backoffice/ActivitiesBackOffice/ActivitiesTable.js
@@ -4,7 +4,7 @@ import { showSuccessAlert } from "../../../Utils/alerts";
 import { Table, Thead, Tbody, Tr, Th, Td } from "react-super-responsive-table";
 import "react-super-responsive-table/dist/SuperResponsiveTableStyle.css";
 import "../../../Styles/TableStyle.css";
-import { getAllActivities, deleteActivity} from '../../../app/activitiesReducer/activitiesReducer';
+import { getAll, deleteById } from '../../../app/activitiesReducer/activitiesReducer';
 import { useHistory } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
 
@@ -15,12 +15,12 @@ const ActivitiesTable = () => {
   const editData = (id) => history.push(`/activity-detail/${id}`);
 
   const deleteData = (id) => {
-    dispatch(deleteActivity(id));
+    dispatch(deleteById(id));
     showSuccessAlert("Delete Activity");
   };
 
   useEffect(() => {
-    dispatch(getAllActivities());
+    dispatch(getAll());
   }, [])
 
   return (

--- a/src/Components/Backoffice/ActivitiesBackOffice/ActivitiesTable.js
+++ b/src/Components/Backoffice/ActivitiesBackOffice/ActivitiesTable.js
@@ -1,29 +1,26 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { showSuccessAlert } from "../../../Utils/alerts";
-import { deleteActivity } from "../../../Utils/handlers";
 import { Table, Thead, Tbody, Tr, Th, Td } from "react-super-responsive-table";
 import "react-super-responsive-table/dist/SuperResponsiveTableStyle.css";
 import "../../../Styles/TableStyle.css";
-import { getAllActivities, deleteActivityById } from "../../../Services/activityService";
+import { getAllActivities, deleteActivity} from '../../../app/activitiesReducer/activitiesReducer';
 import { useHistory } from "react-router-dom";
+import { useSelector, useDispatch } from "react-redux";
 
 const ActivitiesTable = () => {
-  const [dataActivity, setDataActivity] = useState([]);
   const history = useHistory();
-
+  const { activities: dataActivity } = useSelector(state => state.activities);
+  const dispatch = useDispatch();
   const editData = (id) => history.push(`/activity-detail/${id}`);
 
   const deleteData = (id) => {
-    deleteActivityById(id)
-      .then(response => {
-        setDataActivity(deleteActivity(id, dataActivity));
-        showSuccessAlert("Delete Activity");
-      })
+    dispatch(deleteActivity(id));
+    showSuccessAlert("Delete Activity");
   };
 
   useEffect(() => {
-    getAllActivities().then(allActivities => setDataActivity(allActivities));
+    dispatch(getAllActivities());
   }, [])
 
   return (

--- a/src/Components/common/ckEditor/setCKEditorText.js
+++ b/src/Components/common/ckEditor/setCKEditorText.js
@@ -1,4 +1,3 @@
 export const setCKEditorText = (values,field)=>{
-    values[field]=values[field].replace(/'<p>'|['</p>']|<strong>|['</strong>']/gi,'');
-    return values
+    return values[field].replace(/'<p>'|['</p>']|<strong>|['</strong>']/gi,'');
 };

--- a/src/Services/activityService.js
+++ b/src/Services/activityService.js
@@ -40,7 +40,7 @@ export const deleteById = async (activityId) => {
 export const createOrUpdate = async (body, activityId) => {
   if (activityId) {
     await getActivity(activityId);
-    const data = await modifyActivity(body, ac);
+    const data = await modifyActivity(body, activityId);
     return data;
   } else if (!activityId && body) {
     const data = await createActivity(body);

--- a/src/Services/activityService.js
+++ b/src/Services/activityService.js
@@ -19,14 +19,14 @@ export const getAll = async () => {
 export const create = async (body) => {
   return await axios
     .post(`${URL}`, body)
-    .then((response) => response.data)
+    .then((response) => response.data.data)
     .catch(() => alert.CREATE_ERROR("la actividad"));
 };
 
 export const update = async (id, body) => {
   return await axios
     .put(`${URL}/${id}`, body)
-    .then((response) => response.data)
+    .then((response) => response.data.data)
     .catch(() => alert.UPDATE_ERROR("la actividad"));
 };
 
@@ -39,11 +39,11 @@ export const deleteById = async (activityId) => {
 
 export const createOrUpdate = async (body, activityId) => {
   if (activityId) {
-    await getActivity(activityId);
-    const data = await modifyActivity(body, activityId);
+    await getById(activityId);
+    const data = await update(activityId, body);
     return data;
   } else if (!activityId && body) {
-    const data = await createActivity(body);
+    const data = await create(body);
     return data;
   }
 };

--- a/src/app/activitiesReducer/activitiesReducer.js
+++ b/src/app/activitiesReducer/activitiesReducer.js
@@ -51,7 +51,7 @@ const activitiesSlice = createSlice({
         [createOrUpdate.pending]: (state) => { state.status = 'loading'},
         [createOrUpdate.fulfilled]: (state, action) => {
             state.status = 'success';
-            getAll(action.payload.id);
+            state.activities = [...state.activities, action.payload];
         },
         [createOrUpdate.rejected]: (state) => { state.status = 'failed' }
     }

--- a/src/app/activitiesReducer/activitiesReducer.js
+++ b/src/app/activitiesReducer/activitiesReducer.js
@@ -1,25 +1,12 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import * as activityService from '../../Services/activityService';
-import axios from 'axios';
 
-const URL = process.env.REACT_APP_ACTIVITY_URL
+export const getAllActivities = createAsyncThunk("activities/getAllActivities", activityService.getAllActivities);
+export const getActivity = createAsyncThunk('activities/getActivity', activityService.getActivityById);
+export const createActivity = createAsyncThunk('activities/createActivity', activityService.createActivity);
+export const updateActivity = createAsyncThunk('activities/updateActivity', activityService.modifyActivity);
+export const deleteActivity = createAsyncThunk('activities/deleteActivity', activityService.deleteActivityById);
 
-export const getAllActivities = createAsyncThunk(
-    "activities/getAllActivities",
-    activityService.getAllActivities
-)
-export const getActivity = createAsyncThunk(
-    'activities/getActivity',
-    activityService.getActivityById
-)
-export const createOrUpdateActivity = createAsyncThunk(
-    'activities/createOrUpdateActivity',
-    activityService.createOrUpdateActivity
-)
-export const deleteActivity = createAsyncThunk(
-    'activities/deleteActivity',
-    activityService.deleteActivityById()
-)
 const activitiesSlice = createSlice({
     name:"activitiesReducer",
     initialState: {
@@ -28,27 +15,30 @@ const activitiesSlice = createSlice({
         status: ''
     },
     extraReducers: {
-        [getAllActivities.pending]: (state) => state.status = 'loading',
+        [getAllActivities.pending]: (state) => { state.status = 'loading' },
         [getAllActivities.fulfilled]: (state, action) => {
             state.status = 'success';
             state.activities = action.payload;
         },
-        [getAllActivities.rejected]: (state) => state.status = 'failed',
-        [getActivity.pending]: (state) => state.status = 'loading',
+        [getAllActivities.rejected]: (state) => { state.status = 'failed' },
+        [getActivity.pending]: (state) => { state.status = 'loading' },
         [getActivity.fulfilled]: (state, action) => {
             state.status = 'success';
-            state.activity = action.payload;
+            state.activity = action.payload.data;
         },
-        [getActivity.rejected]: (state) => state.status = 'failed',
-        [createOrUpdateActivity.pending]: (state) => state.status = 'loading',
+        [getActivity.rejected]: (state) => { state.status = 'failed' },
+        [createOrUpdateActivity.pending]: (state) => { state.status = 'loading' },
         [createOrUpdateActivity.fulfilled]: (state, action) => {
             state.status = 'sucess';
             state.activity = action.payload;
         },
-        [createOrUpdateActivity.rejected]: (state) => state.status = 'failed',
-        [deleteActivity.pending]: (state) => state.status = 'loading',
-        [deleteActivity.fulfilled]: (state) => state.status = 'success',
-        [deleteActivity.rejected]: (state) => state.status = 'failed'
+        [createOrUpdateActivity.rejected]: (state) => { state.status = 'failed' },
+        [deleteActivity.pending]: (state) => { state.status = 'loading' },
+        [deleteActivity.fulfilled]: (state, action) => {
+            state.status = 'success';
+            state.activities = state.activities.filter(deletedActivity => deletedActivity.id != action.meta.arg);
+        },
+        [deleteActivity.rejected]: (state) => { state.status = 'failed' }
     }
 });
 

--- a/src/app/activitiesReducer/activitiesReducer.js
+++ b/src/app/activitiesReducer/activitiesReducer.js
@@ -1,0 +1,53 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+const URL = process.env.REACT_APP_ACTIVITY_URL
+
+export const getAllActivities = createAsyncThunk(
+    "activities/getAllActivities",
+    async () => {
+        return await axios.get(URL)
+            .then(response => response.data.data);
+    }
+)
+
+export const getActivity = createAsyncThunk(
+    'activities/getActivity',
+    async(id) => {
+        return await axios.get(`${URL}/${id}`)
+            .then(response => response.data.data)
+    }
+)
+
+const activitiesSlice = createSlice({
+    name:"activitiesReducer",
+    initialState: {
+        activities: [],
+        activity: {},
+        status: ''
+    },
+    extraReducers: {
+        [getAllActivities.pending]: (state, action) => {
+            state.status = 'loading';
+        },
+        [getAllActivities.fulfilled]: (state, action) => {
+            state.status = 'success';
+            state.activities = action.payload;
+        },
+        [getAllActivities.rejected]: (state, action) => {
+            state.status = 'failed';
+        },
+        [getActivity.pending]: (state, action) => {
+            state.status = 'loading';
+        },
+        [getActivity.fulfilled]: (state, action) => {
+            state.status = 'success';
+            state.activity = action.payload;
+        },
+        [getActivity.pending]: (state, action) => {
+            state.status = 'failed';
+        },
+    }
+});
+
+export default activitiesSlice.reducer;

--- a/src/app/activitiesReducer/activitiesReducer.js
+++ b/src/app/activitiesReducer/activitiesReducer.js
@@ -19,7 +19,8 @@ const activitiesSlice = createSlice({
         [getAll.pending]: (state) => { state.status = 'loading' },
         [getAll.fulfilled]: (state, action) => {
             state.status = 'success';
-            state.activities |= action.payload;
+            console.log(action)
+            state.activities = action.payload;
         },
         [getAll.rejected]: (state) => { state.status = 'failed' },
         [getById.pending]: (state) => { state.status = 'loading' },

--- a/src/app/activitiesReducer/activitiesReducer.js
+++ b/src/app/activitiesReducer/activitiesReducer.js
@@ -1,24 +1,25 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import * as activityService from '../../Services/activityService';
 import axios from 'axios';
 
 const URL = process.env.REACT_APP_ACTIVITY_URL
 
 export const getAllActivities = createAsyncThunk(
     "activities/getAllActivities",
-    async () => {
-        return await axios.get(URL)
-            .then(response => response.data.data);
-    }
+    activityService.getAllActivities
 )
-
 export const getActivity = createAsyncThunk(
     'activities/getActivity',
-    async(id) => {
-        return await axios.get(`${URL}/${id}`)
-            .then(response => response.data.data)
-    }
+    activityService.getActivityById
 )
-
+export const createOrUpdateActivity = createAsyncThunk(
+    'activities/createOrUpdateActivity',
+    activityService.createOrUpdateActivity
+)
+export const deleteActivity = createAsyncThunk(
+    'activities/deleteActivity',
+    activityService.deleteActivityById()
+)
 const activitiesSlice = createSlice({
     name:"activitiesReducer",
     initialState: {
@@ -27,26 +28,27 @@ const activitiesSlice = createSlice({
         status: ''
     },
     extraReducers: {
-        [getAllActivities.pending]: (state, action) => {
-            state.status = 'loading';
-        },
+        [getAllActivities.pending]: (state) => state.status = 'loading',
         [getAllActivities.fulfilled]: (state, action) => {
             state.status = 'success';
             state.activities = action.payload;
         },
-        [getAllActivities.rejected]: (state, action) => {
-            state.status = 'failed';
-        },
-        [getActivity.pending]: (state, action) => {
-            state.status = 'loading';
-        },
+        [getAllActivities.rejected]: (state) => state.status = 'failed',
+        [getActivity.pending]: (state) => state.status = 'loading',
         [getActivity.fulfilled]: (state, action) => {
             state.status = 'success';
             state.activity = action.payload;
         },
-        [getActivity.pending]: (state, action) => {
-            state.status = 'failed';
+        [getActivity.rejected]: (state) => state.status = 'failed',
+        [createOrUpdateActivity.pending]: (state) => state.status = 'loading',
+        [createOrUpdateActivity.fulfilled]: (state, action) => {
+            state.status = 'sucess';
+            state.activity = action.payload;
         },
+        [createOrUpdateActivity.rejected]: (state) => state.status = 'failed',
+        [deleteActivity.pending]: (state) => state.status = 'loading',
+        [deleteActivity.fulfilled]: (state) => state.status = 'success',
+        [deleteActivity.rejected]: (state) => state.status = 'failed'
     }
 });
 

--- a/src/app/activitiesReducer/activitiesReducer.js
+++ b/src/app/activitiesReducer/activitiesReducer.js
@@ -1,12 +1,12 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import * as activityService from '../../Services/activityService';
 
-export const getAllActivities = createAsyncThunk("activities/getAllActivities", activityService.getAllActivities);
-export const getActivity = createAsyncThunk('activities/getActivity', activityService.getActivityById);
-export const createActivity = createAsyncThunk('activities/createActivity', activityService.createActivity);
-export const updateActivity = createAsyncThunk('activities/updateActivity', activityService.modifyActivity);
-export const deleteActivity = createAsyncThunk('activities/deleteActivity', activityService.deleteActivityById);
-export const createOrUpdateActivity = createAsyncThunk('activities/createOrUpdateActivity', activityService.createOrUpdateActivity);
+export const getAll = createAsyncThunk("activities/getAll", activityService.getAll);
+export const getById = createAsyncThunk('activities/getById', activityService.getById);
+export const create = createAsyncThunk('activities/create', activityService.create);
+export const update = createAsyncThunk('activities/update', activityService.update);
+export const deleteById = createAsyncThunk('activities/delete', activityService.deleteById);
+export const createOrUpdate = createAsyncThunk('activities/createOrupdate', activityService.createOrUpdate);
 
 const activitiesSlice = createSlice({
     name:"activitiesReducer",
@@ -16,43 +16,43 @@ const activitiesSlice = createSlice({
         status: ''
     },
     extraReducers: {
-        [getAllActivities.pending]: (state) => { state.status = 'loading' },
-        [getAllActivities.fulfilled]: (state, action) => {
+        [getAll.pending]: (state) => { state.status = 'loading' },
+        [getAll.fulfilled]: (state, action) => {
             state.status = 'success';
-            state.activities = action.payload;
+            state.activities |= action.payload;
         },
-        [getAllActivities.rejected]: (state) => { state.status = 'failed' },
-        [getActivity.pending]: (state) => { state.status = 'loading' },
-        [getActivity.fulfilled]: (state, action) => {
+        [getAll.rejected]: (state) => { state.status = 'failed' },
+        [getById.pending]: (state) => { state.status = 'loading' },
+        [getById.fulfilled]: (state, action) => {
             state.status = 'success';
-            state.activity = action.payload.data;
+            state.activity |= action.payload;
         },
-        [getActivity.rejected]: (state) => { state.status = 'failed' },
-        [deleteActivity.pending]: (state) => { state.status = 'loading' },
-        [deleteActivity.fulfilled]: (state, action) => {
+        [getById.rejected]: (state) => { state.status = 'failed' },
+        [deleteById.pending]: (state) => { state.status = 'loading' },
+        [deleteById.fulfilled]: (state, action) => {
             state.status = 'success';
             state.activities = state.activities.filter(deletedActivity => deletedActivity.id != action.meta.arg);
         },
-        [deleteActivity.rejected]: (state) => { state.status = 'failed' },
-        [createActivity.pending]: (state) => { state.status = 'loading' },
-        [createActivity.fulfilled]: (state, action) => {
+        [deleteById.rejected]: (state) => { state.status = 'failed' },
+        [create.pending]: (state) => { state.status = 'loading' },
+        [create.fulfilled]: (state, action) => {
             state.status = 'success';
             state.activities = [...state.activities, action.payload];
         },
-        [createActivity.rejected]: (state) => { state.status = 'failed' },
-        [updateActivity.pending]: (state) => { state.status = 'loading' },
-        [updateActivity.fulfilled]: (state, action) => {
+        [create.rejected]: (state) => { state.status = 'failed' },
+        [update.pending]: (state) => { state.status = 'loading' },
+        [update.fulfilled]: (state, action) => {
             state.status = 'success';
             const updatedActivityIndex = state.activities.findIndex(activity => activity.id == action.payload.id);
             state.activities[updatedActivityIndex] = action.payload;
         },
-        [updateActivity.rejected]: (state) => { state.status = 'failed' },
-        [createOrUpdateActivity.pending]: (state) => { state.status = 'loading'},
-        [createOrUpdateActivity.fulfilled]: (state, action) => {
+        [update.rejected]: (state) => { state.status = 'failed' },
+        [createOrUpdate.pending]: (state) => { state.status = 'loading'},
+        [createOrUpdate.fulfilled]: (state, action) => {
             state.status = 'success';
-            getAllActivities(action.payload.id);
+            getAll(action.payload.id);
         },
-        [createOrUpdateActivity.rejected]: (state) => { state.status = 'failed' }
+        [createOrUpdate.rejected]: (state) => { state.status = 'failed' }
     }
 });
 

--- a/src/app/activitiesReducer/activitiesReducer.js
+++ b/src/app/activitiesReducer/activitiesReducer.js
@@ -4,9 +4,15 @@ import * as activityService from '../../Services/activityService';
 export const getAll = createAsyncThunk("activities/getAll", activityService.getAll);
 export const getById = createAsyncThunk('activities/getById', activityService.getById);
 export const create = createAsyncThunk('activities/create', activityService.create);
-export const update = createAsyncThunk('activities/update', activityService.update);
+export const update = createAsyncThunk(
+    'activities/update',
+    async (state) => activityService.update(state.id, state)
+    );
 export const deleteById = createAsyncThunk('activities/delete', activityService.deleteById);
-export const createOrUpdate = createAsyncThunk('activities/createOrupdate', activityService.createOrUpdate);
+export const createOrUpdate = createAsyncThunk(
+    'activities/createOrupdate',
+    async (state) => activityService.createOrUpdate(state, state.id)
+    );
 
 const activitiesSlice = createSlice({
     name:"activitiesReducer",
@@ -19,14 +25,13 @@ const activitiesSlice = createSlice({
         [getAll.pending]: (state) => { state.status = 'loading' },
         [getAll.fulfilled]: (state, action) => {
             state.status = 'success';
-            console.log(action)
             state.activities = action.payload;
         },
         [getAll.rejected]: (state) => { state.status = 'failed' },
         [getById.pending]: (state) => { state.status = 'loading' },
         [getById.fulfilled]: (state, action) => {
             state.status = 'success';
-            state.activity |= action.payload;
+            state.activity = action.payload || state.activity;
         },
         [getById.rejected]: (state) => { state.status = 'failed' },
         [deleteById.pending]: (state) => { state.status = 'loading' },
@@ -38,7 +43,7 @@ const activitiesSlice = createSlice({
         [create.pending]: (state) => { state.status = 'loading' },
         [create.fulfilled]: (state, action) => {
             state.status = 'success';
-            state.activities = [...state.activities, action.payload];
+            state.activities.push(action.payload);
         },
         [create.rejected]: (state) => { state.status = 'failed' },
         [update.pending]: (state) => { state.status = 'loading' },
@@ -51,7 +56,10 @@ const activitiesSlice = createSlice({
         [createOrUpdate.pending]: (state) => { state.status = 'loading'},
         [createOrUpdate.fulfilled]: (state, action) => {
             state.status = 'success';
-            state.activities = [...state.activities, action.payload];
+            const updatedActivityIndex = state.activities.findIndex(activity => activity.id == action.payload.id);
+            const isUpdateAction = updatedActivityIndex >= 0;
+            if(isUpdateAction) state.activities[updatedActivityIndex] = action.payload;
+            else state.activities.push(action.payload)
         },
         [createOrUpdate.rejected]: (state) => { state.status = 'failed' }
     }

--- a/src/app/activitiesReducer/activitiesReducer.js
+++ b/src/app/activitiesReducer/activitiesReducer.js
@@ -6,6 +6,7 @@ export const getActivity = createAsyncThunk('activities/getActivity', activitySe
 export const createActivity = createAsyncThunk('activities/createActivity', activityService.createActivity);
 export const updateActivity = createAsyncThunk('activities/updateActivity', activityService.modifyActivity);
 export const deleteActivity = createAsyncThunk('activities/deleteActivity', activityService.deleteActivityById);
+export const createOrUpdateActivity = createAsyncThunk('activities/createOrUpdateActivity', activityService.createOrUpdateActivity);
 
 const activitiesSlice = createSlice({
     name:"activitiesReducer",
@@ -27,18 +28,31 @@ const activitiesSlice = createSlice({
             state.activity = action.payload.data;
         },
         [getActivity.rejected]: (state) => { state.status = 'failed' },
-        [createOrUpdateActivity.pending]: (state) => { state.status = 'loading' },
-        [createOrUpdateActivity.fulfilled]: (state, action) => {
-            state.status = 'sucess';
-            state.activity = action.payload;
-        },
-        [createOrUpdateActivity.rejected]: (state) => { state.status = 'failed' },
         [deleteActivity.pending]: (state) => { state.status = 'loading' },
         [deleteActivity.fulfilled]: (state, action) => {
             state.status = 'success';
             state.activities = state.activities.filter(deletedActivity => deletedActivity.id != action.meta.arg);
         },
-        [deleteActivity.rejected]: (state) => { state.status = 'failed' }
+        [deleteActivity.rejected]: (state) => { state.status = 'failed' },
+        [createActivity.pending]: (state) => { state.status = 'loading' },
+        [createActivity.fulfilled]: (state, action) => {
+            state.status = 'success';
+            state.activities = [...state.activities, action.payload];
+        },
+        [createActivity.rejected]: (state) => { state.status = 'failed' },
+        [updateActivity.pending]: (state) => { state.status = 'loading' },
+        [updateActivity.fulfilled]: (state, action) => {
+            state.status = 'success';
+            const updatedActivityIndex = state.activities.findIndex(activity => activity.id == action.payload.id);
+            state.activities[updatedActivityIndex] = action.payload;
+        },
+        [updateActivity.rejected]: (state) => { state.status = 'failed' },
+        [createOrUpdateActivity.pending]: (state) => { state.status = 'loading'},
+        [createOrUpdateActivity.fulfilled]: (state, action) => {
+            state.status = 'success';
+            getAllActivities(action.payload.id);
+        },
+        [createOrUpdateActivity.rejected]: (state) => { state.status = 'failed' }
     }
 });
 

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,4 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit';
+import activitiesReducer from './activitiesReducer/activitiesReducer';
 import authReducer from './authReducer/authReducer';
 import membersReducer from './MembersReducer/membersReducer';
 
@@ -6,7 +7,8 @@ const store = configureStore({
   reducer: {
     authorization: authReducer,
     members: membersReducer,
-   },
+    activities: activitiesReducer
+  },
 });
 
 export default store


### PR DESCRIPTION
User story link: https://alkemy-labs.atlassian.net/browse/OT91-108

**##SUMMARY**
Create activities reducer using activityService logic.

**##CHANGES ADDED**
- Functions for handling store with async thunks: Using Redux Toolkit
- Connect the activities reducer with the corresponding components: Using useSelector and useDispatch
- Adapt setCKEditorText to work with reducer state.

**##SCREENSHOOTS**
To show that the actions of reducer works correctly
- create 
![image](https://user-images.githubusercontent.com/50643955/142904112-70b46912-12bb-4983-9b22-6a5e2a2641ef.png)
- getById (Using the id of the newly created activity)
![image](https://user-images.githubusercontent.com/50643955/142904339-47417bc6-8ea8-428f-8e3a-0a420f0b56cf.png)
- update
![image](https://user-images.githubusercontent.com/50643955/142904882-1f452a77-d303-450e-825c-35afa81ef00c.png)
- getById (Just to show the updated activity)
![image](https://user-images.githubusercontent.com/50643955/142908146-8ca3d485-d004-4ccd-b973-0f715d54b77d.png)
- getAll
![image](https://user-images.githubusercontent.com/50643955/142911787-0b6e98c4-7237-4d32-bfb2-f3175b03a66e.png)
- deleteById
![image](https://user-images.githubusercontent.com/50643955/142911955-92a72e7d-2377-4e7a-87ab-b94502a1899f.png)
- createOrUpdate was tested in the same way as create and update, and it is the one that is actually used in the activity creation/editing form