### PR TITLE
Bugfix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prettier": "^2.0.5"
   },
   "scripts": {
-    "start": "react-scripts --openssl-legacy-provider start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
##Summary
The start line in the package.json was fixed, it was ==> "start": "react-scripts --openssl-legacy-provider start",
is changed to ==> "start": "react-scripts start",

##Evidence

https://user-images.githubusercontent.com/72997924/143467557-1e9bb5b2-e260-4e42-b86e-005aa7f6c480.mp4

