### PR TITLE
Feat/Novedaes/Crear-formulario-de-busqueda-de-Novedades-Web-Publica

### DIFF
--- a/src/Components/News/NewList/NewsList.js
+++ b/src/Components/News/NewList/NewsList.js
@@ -9,12 +9,13 @@ import { videoLastEvent } from "./videoEvent";
 import CardSection from "../../Home/CardsSection";
 import { getAll } from "../../../Services/newsServices";
 import novedades from "../../../Assets/TitleImages/novedades.jpg";
-
+import Seeker from "../../Seeker/Seeker";
 const NewsList = () => {
   return (
     <div>
       <Title title="Novedades" image={novedades} />
-      <CardSection getInformation={getAll} clickeable={{to:'/novedades'}} />
+      <Seeker endpointName="news" minLength="3" />
+      <CardSection getInformation={getAll} clickeable={{ to: "/novedades" }} />
       <VideoCard
         title={videoLastEvent.name}
         video={videoLastEvent.video}

--- a/src/Components/Seeker/Seeker.js
+++ b/src/Components/Seeker/Seeker.js
@@ -15,7 +15,7 @@ import {
 
 import CustomCard from "../Card/CustomCard";
 import { searchIn } from "../../Services/seekerService";
-
+import { setCKEditorText } from "../../Components/common/ckEditor/setCKEditorText";
 const Seeker = ({ endpointName, minLength }) => {
   const [targetValue, setTargetValue] = useState("");
   const [isLoading, setIsLoading] = useState(true);
@@ -62,8 +62,12 @@ const Seeker = ({ endpointName, minLength }) => {
               <Grid item xs={6} md={4} key={element.id}>
                 <CustomCard
                   title={element.name}
-                  image={element.image}
-                  description={element.description}
+                  img={element.image}
+                  description={
+                    (element.content && setCKEditorText(element, "content")) ||
+                    (element.description &&
+                      setCKEditorText(element, "description"))
+                  }
                 />
               </Grid>
             ))}


### PR DESCRIPTION
:small_orange_diamond:**SUMMARY**:small_orange_diamond:

To optimize the search experience, this PR adds a search component to the news feed.
This component was created in a previous PR _(https://github.com/alkemyTech/OT91-Client/pull/145_) with everything necessary to be able to be reused in the tickets of all the colleagues who had search engines. That is why it uses the direct service call, as few components count as NewList with the use of Redux.
The developed search engine receives the necessary parameters to make the call and the validation according to the component that uses it. In the case of NewList, the validation is at least 3 characters to start the search, if it does not reach three it will show the complete list of news.

:small_orange_diamond:**CHANGES**:small_orange_diamond:

- On demo days the card component was modified, so change some props in the seeker component so that the cards will re-render the data correctly.
- Coming directly from the service, the descriptions came with the html tags, so I applied the function to remove them.
- Add the finder to the NewList component

:small_orange_diamond:**EVIDENCE**:small_orange_diamond:
https://www.loom.com/share/8f5e36648222435a8f8f76914cede27f

:small_orange_diamond:**USER STORY**:small_orange_diamond:
https://alkemy-labs.atlassian.net/jira/software/c/projects/OT91/boards/145?modal=detail&selectedIssue=OT91-163&assignee=70121%3Aad4a2c05-0941-42e8-af44-540b8eff3169