### PR TITLE
Search bar for members in backoffice

### DIFF
--- a/src/Components/Backoffice/Members/MembersResults.js
+++ b/src/Components/Backoffice/Members/MembersResults.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import {
   Table,
   TableBody,
@@ -14,23 +14,44 @@ import { useDispatch, useSelector } from "react-redux";
 import { getAll } from "../../../app/MembersReducer/membersReducer";
 import TitleBackoffice from "../../Backoffice/TitleBackoffice";
 import { useHistory } from "react-router-dom";
+import MembersResultsSearchedItem from "./MembersResultsSearchedItems";
+import { TextField, Spinner, Box } from "@mui/material";
+
 const MembersResults = () => {
+  const [isSearching, setIsSearching] = useState(false);
+  const [targetValue, setTargetValue] = useState("");
   const dispatch = useDispatch();
   const members = useSelector((state) => state.members.data);
   const showMembers = () =>
-    members.map((member) => (
-      <MembersResultsItem
-        item={member}
-      />
-    ));
-
+    members.map((member) => <MembersResultsItem item={member} />);
+  const targetValueSearch = (e) => {
+    setTargetValue(e.target.value);
+    setIsSearching(true);
+  };
   useEffect(() => {
     dispatch(getAll());
-  }, []);
+    targetValue.length == 0 && setIsSearching(false);
+  }, [targetValue]);
 
   return (
     <>
       <TitleBackoffice title={"Edición de Miembros"} />
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          m: 4,
+        }}
+      >
+        <TextField
+          sx={{ width: "75%" }}
+          controlId="floatingInput"
+          label="Ingrese su busqueda"
+          className="d-flex"
+          onChange={targetValueSearch}
+        />
+      </Box>
+
       <TableContainer className="TableContainer">
         <Table className="TableFinal">
           <TableHead className="TableRowModify">
@@ -57,7 +78,16 @@ const MembersResults = () => {
               </TableCell>
             </TableRow>
           </TableHead>
-          <TableBody color="tablebackground">{showMembers()}</TableBody>
+          {isSearching ? (
+            <MembersResultsSearchedItem
+              endpointName="members"
+              minLength="2"
+              targetValue={targetValue}
+              setIsSearching={setIsSearching}
+            />
+          ) : (
+            <TableBody color="tablebackground">{showMembers()}</TableBody>
+          )}
         </Table>
       </TableContainer>
     </>

--- a/src/Components/Backoffice/Members/MembersResultsItem.js
+++ b/src/Components/Backoffice/Members/MembersResultsItem.js
@@ -1,25 +1,21 @@
-import React, { useEffect } from "react";
-import { TableCell, TableRow, Button, IconButton } from "@mui/material";
+import React from "react";
+import { TableCell, TableRow, IconButton } from "@mui/material";
 import { Edit, Delete } from "@mui/icons-material";
 import { formatDate } from "../../../Utils/formatters";
-import { Link } from "react-router-dom";
 import "../../../Styles/TableStyle.css";
 import * as membersActions from "../../../app/MembersReducer/membersReducer";
 import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
-import { getMember } from "../../../Services/membersService";
 
 const MembersResultsItem = ({ item }) => {
   const dispatch = useDispatch();
   const history = useHistory();
-
   const onEdit = (id) => {
     dispatch(membersActions.getById(id)).then(() => {
       history.push(`/backoffice/members/edit/${id}`);
     });
   };
   const onDelete = (id) => dispatch(membersActions.deletebyId(id));
-
   const members = useSelector((state) => state.members.data);
 
   return (

--- a/src/Components/Backoffice/Members/MembersResultsSearchedItems.js
+++ b/src/Components/Backoffice/Members/MembersResultsSearchedItems.js
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from "react";
+import LoadingSpinner from "../../../Utils/loadingSpinner";
+import { TextField, Box } from "@mui/material";
+import {
+  TableCell,
+  TableRow,
+  TableBody,
+  Button,
+  IconButton,
+} from "@mui/material";
+import { Edit, Delete } from "@mui/icons-material";
+import { formatDate } from "../../../Utils/formatters";
+import { searchIn } from "../../../Services/seekerService";
+import MembersResultsItem from "./MembersResultsItem";
+
+const MembersResultsSearchedItem = ({
+  endpointName,
+  minLength,
+  targetValue,
+}) => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [result, setResult] = useState([]);
+  const showresults = async () => {
+    setIsLoading(true);
+    await searchIn(endpointName, targetValue, minLength).then((res) => {
+      setResult(res);
+      setIsLoading(false);
+    });
+  };
+  useEffect(() => {
+    showresults();
+  }, [targetValue]);
+
+  return (
+    <>
+      {targetValue && !isLoading ? (
+        <TableBody>
+          {result.map((item) => (
+            <TableRow key={item.name}>
+              <TableCell component="th" scope="row">
+                {item && item.name}
+              </TableCell>
+              <TableCell align="center">
+                <img
+                  className="table-row-image"
+                  src={item && item.image}
+                  alt={item && item.name}
+                  key={item && item.id}
+                />
+              </TableCell>
+              <TableCell align="center">{formatDate(new Date())}</TableCell>
+              <TableCell align="center">
+                <IconButton onClick={() => onEdit(item.id)}>
+                  <Edit />
+                </IconButton>
+                <IconButton onClick={() => onDelete(item.id)}>
+                  <Delete />
+                </IconButton>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      ) : isLoading ? (
+        <div className="d-flex justify-content-center m-5">
+          <LoadingSpinner />
+        </div>
+      ) : (
+        ""
+      )}
+    </>
+  );
+};
+
+export default MembersResultsSearchedItem;


### PR DESCRIPTION
### Summary
Search bar in backoffice members showing only members corresponding with the searched values.

### Changes Added
- Conditional rendering when a value is enter in the search bar, showing only searched values ​​from two characters, otherwise show them all.
- Reuse of `SeekerService`.
- `MembersResultsSearchedItems` new file for searched results.

### Screenshot
![backoffice members search bar](https://user-images.githubusercontent.com/73605405/144443480-073f8ec9-c760-4166-b617-6962fd3764fe.gif)