### PR TITLE
[Feat] Crear formulario de búsqueda de actividades

### DIFF
--- a/src/Components/Backoffice/ActivitiesBackOffice/ActivitiesTable.js
+++ b/src/Components/Backoffice/ActivitiesBackOffice/ActivitiesTable.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { showSuccessAlert } from "../../../Utils/alerts";
 import "../../../Styles/TableStyle.css";
-import { getAll, deleteById } from '../../../app/activitiesReducer/activitiesReducer';
+import { search, deleteById } from '../../../app/activitiesReducer/activitiesReducer';
 import { useHistory } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
 import {NewsTableRows} from '../../News/NewsTableRows';
@@ -10,6 +10,8 @@ import {Table,TableBody,TableCell,TableContainer,TableHead,Button,TableRow,IconB
 import { Edit, Delete } from "@mui/icons-material";
 import TitleBackoffice from '../TitleBackoffice'
 import { formatDate } from "../../../Utils/formatters";
+import SearchInput from './SearchInput';
+
 const ActivitiesTable = () => {
   const history = useHistory();
   const { activities } = useSelector(state => state.activities);
@@ -20,65 +22,60 @@ const ActivitiesTable = () => {
     dispatch(deleteById(id));
     showSuccessAlert("Delete Activity");
   };
-
-  useEffect(() => {
-    dispatch(getAll());
-  }, [])
+  const searchActivities = (searchedValue, minLength) => dispatch(search({searchedValue, minLength}))
 
   return (
     <>
      <TitleBackoffice title={"Edición de Actividades"} />
+      <SearchInput searchAction={searchActivities} minLength={3}/>
       <TableContainer className="TableContainer">
-      <Table className="TableFinal">
-        <TableHead className="TableRowModify">
-          <TableRow>
-            <TableCell className="TableCell"align="center">Name</TableCell>
-            <TableCell className="TableCell"align="center">Image</TableCell>
-            <TableCell className="TableCell"align="center">CreatedAt</TableCell>
-            <TableCell align="center" className="TableCell">
-                  <Button
-                    color="buttoncreatenews"
-                    variant="contained"
-                    size="small"
-                    component={Link}
-                    to="/backoffice/activities/create"
-                  >
-                    Create Activity
-                  </Button>
-                </TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {activities.map((activity) => (
-          <TableRow key={activity.id}>
-            <TableCell component="th" scope="row">
-              {activity.name}
-            </TableCell>
-            <TableCell align="center">
-              <img
-                className="table-row-image"
-                src={activity.image}
-                alt={activity.name}
-              />
-            </TableCell>
-            <TableCell align="center">{formatDate(new Date())}</TableCell>
-            <TableCell align="center">
-              <IconButton onClick={() => editData(activity.id)}>
-                <Edit />
-              </IconButton>
-              <IconButton
-                onClick={() => {
-                  deleteData(activity.id);
-                  newsDeleted();
-                }}
-              >
-                <Delete />
-              </IconButton>
-            </TableCell>
-          </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+        <Table className="TableFinal">
+          <TableHead className="TableRowModify">
+            <TableRow>
+              <TableCell className="TableCell"align="center">Name</TableCell>
+              <TableCell className="TableCell"align="center">Image</TableCell>
+              <TableCell className="TableCell"align="center">CreatedAt</TableCell>
+              <TableCell align="center" className="TableCell">
+                    <Button
+                      color="buttoncreatenews"
+                      variant="contained"
+                      size="small"
+                      component={Link}
+                      to="/backoffice/activities/create"
+                    >
+                      Create Activity
+                    </Button>
+                  </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {activities.map((activity) => (
+            <TableRow key={activity.id}>
+              <TableCell component="th" scope="row">
+                {activity.name}
+              </TableCell>
+              <TableCell align="center">
+                <img
+                  className="table-row-image"
+                  src={activity.image}
+                  alt={activity.name}
+                />
+              </TableCell>
+              <TableCell align="center">{formatDate(new Date())}</TableCell>
+              <TableCell align="center">
+                <IconButton onClick={() => editData(activity.id)}>
+                  <Edit />
+                </IconButton>
+                <IconButton
+                  onClick={() => deleteData(activity.id)}
+                >
+                  <Delete />
+                </IconButton>
+              </TableCell>
+            </TableRow>
+            ))}
+          </TableBody>
+        </Table>
       </TableContainer>
     </>
   );

--- a/src/Components/Backoffice/ActivitiesBackOffice/ActivitiesTable.js
+++ b/src/Components/Backoffice/ActivitiesBackOffice/ActivitiesTable.js
@@ -6,13 +6,15 @@ import { getAll, deleteById } from '../../../app/activitiesReducer/activitiesRed
 import { useHistory } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
 import {NewsTableRows} from '../../News/NewsTableRows';
-import {Table,TableBody,TableCell,TableContainer,TableHead,Button,TableRow} from "@mui/material";
+import {Table,TableBody,TableCell,TableContainer,TableHead,Button,TableRow,IconButton} from "@mui/material";
+import { Edit, Delete } from "@mui/icons-material";
 import TitleBackoffice from '../TitleBackoffice'
+import { formatDate } from "../../../Utils/formatters";
 const ActivitiesTable = () => {
   const history = useHistory();
-  const { activities: dataActivity } = useSelector(state => state.activities);
+  const { activities } = useSelector(state => state.activities);
   const dispatch = useDispatch();
-  const editData = (id) => history.push(`/activity-detail/${id}`);
+  const editData = (id) => history.push(`/backoffice/activities/edit/${id}`);
 
   const deleteData = (id) => {
     dispatch(deleteById(id));
@@ -47,7 +49,34 @@ const ActivitiesTable = () => {
           </TableRow>
         </TableHead>
         <TableBody>
-          <NewsTableRows newsList={dataActivity} onDelete={deleteData} onEdit={editData}/>
+          {activities.map((activity) => (
+          <TableRow key={activity.id}>
+            <TableCell component="th" scope="row">
+              {activity.name}
+            </TableCell>
+            <TableCell align="center">
+              <img
+                className="table-row-image"
+                src={activity.image}
+                alt={activity.name}
+              />
+            </TableCell>
+            <TableCell align="center">{formatDate(new Date())}</TableCell>
+            <TableCell align="center">
+              <IconButton onClick={() => editData(activity.id)}>
+                <Edit />
+              </IconButton>
+              <IconButton
+                onClick={() => {
+                  deleteData(activity.id);
+                  newsDeleted();
+                }}
+              >
+                <Delete />
+              </IconButton>
+            </TableCell>
+          </TableRow>
+          ))}
         </TableBody>
       </Table>
       </TableContainer>

--- a/src/Components/Backoffice/ActivitiesBackOffice/SearchInput.js
+++ b/src/Components/Backoffice/ActivitiesBackOffice/SearchInput.js
@@ -1,0 +1,30 @@
+import { TextField } from '@mui/material';
+import { Box } from '@mui/system';
+import { useEffect, useState } from 'react';
+
+const SearchInput = ({searchAction, minLength}) => {
+    const [searchValue, setsearchValue] = useState("");
+    const handleChange = (event) => {
+        setsearchValue(event.target.value);
+    }
+    useEffect(() => {
+        searchAction(searchValue, minLength);
+    }, [searchValue]);
+    return (
+        <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          mb: 4,
+        }}
+      >
+        <TextField
+          sx={{ width: "75%" }}
+          label="Ingrese su busqueda"
+          onChange={handleChange}
+        />
+      </Box>
+    )
+}
+
+export default SearchInput;

--- a/src/app/activitiesReducer/activitiesReducer.js
+++ b/src/app/activitiesReducer/activitiesReducer.js
@@ -1,5 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import * as activityService from '../../Services/activityService';
+import { searchIn } from '../../Services/seekerService';
 
 export const getAll = createAsyncThunk("activities/getAll", activityService.getAll);
 export const getById = createAsyncThunk('activities/getById', activityService.getById);
@@ -13,6 +14,9 @@ export const createOrUpdate = createAsyncThunk(
     'activities/createOrupdate',
     async (state) => activityService.createOrUpdate(state, state.id)
     );
+export const search = createAsyncThunk('activities/search',
+    async (state) => searchIn('activities', state.searchValue, state.minLength)
+)
 
 const activitiesSlice = createSlice({
     name:"activitiesReducer",
@@ -61,7 +65,13 @@ const activitiesSlice = createSlice({
             if(isUpdateAction) state.activities[updatedActivityIndex] = action.payload;
             else state.activities.push(action.payload)
         },
-        [createOrUpdate.rejected]: (state) => { state.status = 'failed' }
+        [createOrUpdate.rejected]: (state) => { state.status = 'failed' },
+        [search.pending]: (state) => { state.status = 'loading'},
+        [search.fulfilled]: (state, action) => {
+            state.status = 'success';
+            state.activities = action.payload;
+        },
+        [search.rejected]: (state) => { state.status = 'failed' }
     }
 });
 


### PR DESCRIPTION
User story link: https://alkemy-labs.atlassian.net/browse/OT91-166

**##SUMMARY**
These changes add an input to search for activities in the respective table in backoffice, using a debounce effect.

**##CHANGES ADDED**
- SearchInput component: Receives a function that performs the search action (It must be a dispatch of a reducer action) and the minimum length that the search value must have for the search to be carried out.
- Changes in ActivitiesTable: To fix the error that showed the news instead of the reducer activities. And to use the SearchInput component with minLength=3.
- Search reducer: Added in ActivitiesReducer to get the search results from the API

**##EVIDENCE**
https://www.loom.com/share/f921acc05ed243d1b91393e4e7259248